### PR TITLE
Investigate 405 error on summarize endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
 fastapi
 llama-index-readers-web==0.5.0
 llama-index==0.13.2
+llama-index-llms-openai
 uvicorn
+requests
+beautifulsoup4
+html5lib


### PR DESCRIPTION
Add missing Python dependencies to `requirements.txt` to resolve a 500 Internal Server Error on the `/summarize` endpoint.

The `/summarize` endpoint was failing with a 500 error (misinterpreted as 405 by the frontend) because `requests`, `beautifulsoup4`, `html5lib`, and `llama-index-llms-openai` were not installed, preventing the application from fetching web content and using the LLM.

---
<a href="https://cursor.com/background-agent?bcId=bc-e659d4cf-59b0-495d-8176-720e4bd6c731">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e659d4cf-59b0-495d-8176-720e4bd6c731">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

