### PR TITLE
Show error stack traces on server

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import os
 import traceback
+import logging
 from typing import Any, List, Optional
 from fastapi import FastAPI, HTTPException, Response, Request
 from fastapi.exception_handlers import http_exception_handler
@@ -70,8 +71,9 @@ class WebsiteSummarizationWorkflow(Workflow):
             return ContentFetched(content=content, url=url)
             
         except Exception as e:
-            # Re-raise the original exception to let the custom exception handler show the full stack trace
-            raise e
+            # Log the full exception with stack trace for debugging
+            logger.error(f"Failed to fetch content from {url}:\n{traceback.format_exc()}")
+            raise HTTPException(status_code=400, detail=f"Failed to fetch content from {url}: {str(e)}")
 
     @step
     async def generate_summary(self, ev: ContentFetched) -> StopEvent:
@@ -99,8 +101,9 @@ class WebsiteSummarizationWorkflow(Workflow):
             return StopEvent(result={"summary": summary, "url": ev.url})
             
         except Exception as e:
-            # Re-raise the original exception to let the custom exception handler show the full stack trace
-            raise e
+            # Log the full exception with stack trace for debugging
+            logger.error(f"Failed to generate summary:\n{traceback.format_exc()}")
+            raise HTTPException(status_code=500, detail=f"Failed to generate summary: {str(e)}")
 
 
 # Global variables
@@ -130,35 +133,57 @@ app = FastAPI(
 )
 
 
-# Custom exception handler to show stack traces
+# Configure logging to show detailed error information
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    force=True  # Override any existing logging configuration
+)
+logger = logging.getLogger(__name__)
+
+# Also set uvicorn access logger to show more details
+uvicorn_logger = logging.getLogger("uvicorn.access")
+uvicorn_logger.setLevel(logging.DEBUG)
+
+
+# Custom exception handler to log stack traces to server console
 @app.exception_handler(Exception)
 async def general_exception_handler(request: Request, exc: Exception):
     """
-    Handle all unhandled exceptions and return detailed error information including stack trace.
+    Handle all unhandled exceptions, log full stack trace to server console,
+    and return a clean error response to the client.
     """
-    error_detail = {
-        "error": str(exc),
-        "type": type(exc).__name__,
-        "traceback": traceback.format_exc(),
-        "path": str(request.url),
-        "method": request.method
-    }
+    # Log the full stack trace to server console
+    logger.error(
+        f"Unhandled exception in {request.method} {request.url}:\n"
+        f"Exception type: {type(exc).__name__}\n"
+        f"Exception message: {str(exc)}\n"
+        f"Full traceback:\n{traceback.format_exc()}"
+    )
     
     return JSONResponse(
         status_code=500,
         content={
-            "detail": "Internal server error with full stack trace",
-            "error_info": error_detail
+            "detail": "Internal server error",
+            "path": str(request.url),
+            "method": request.method
         }
     )
 
 
-# Enhanced HTTP exception handler to show more details
+# Enhanced HTTP exception handler to log HTTP exceptions
 @app.exception_handler(HTTPException)
 async def custom_http_exception_handler(request: Request, exc: HTTPException):
     """
-    Handle HTTP exceptions with additional context.
+    Handle HTTP exceptions with logging for server-side debugging.
     """
+    # Log HTTP exceptions for debugging
+    logger.warning(
+        f"HTTP exception in {request.method} {request.url}:\n"
+        f"Status code: {exc.status_code}\n"
+        f"Detail: {exc.detail}"
+    )
+    
     error_detail = {
         "status_code": exc.status_code,
         "detail": exc.detail,
@@ -238,8 +263,12 @@ async def summarize_website(request: URLRequest):
     except HTTPException:
         raise
     except Exception as e:
-        # Re-raise the original exception to let the custom exception handler show the full stack trace
-        raise e
+        # Log the full exception with stack trace for debugging
+        logger.error(f"Error in summarize_website endpoint:\n{traceback.format_exc()}")
+        raise HTTPException(
+            status_code=500, 
+            detail=f"An error occurred while summarizing the website: {str(e)}"
+        )
 
 
 @app.options("/summarize")
@@ -260,4 +289,13 @@ async def summarize_options():
 if __name__ == "__main__":
     import uvicorn
     port = int(os.environ.get("PORT", 8000))
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    
+    # Configure uvicorn to show detailed logs and stack traces
+    uvicorn.run(
+        app, 
+        host="0.0.0.0", 
+        port=port,
+        log_level="debug",  # Enable debug logging
+        access_log=True,    # Show access logs
+        use_colors=True     # Enable colored output for better readability
+    )

--- a/test_error_handling.py
+++ b/test_error_handling.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Test script to demonstrate error handling and stack trace logging.
+This script will start the server and make requests that trigger errors
+to show that stack traces are properly logged to the console.
+"""
+
+import requests
+import time
+import subprocess
+import signal
+import sys
+import os
+from threading import Thread
+
+def start_server():
+    """Start the FastAPI server in a subprocess."""
+    env = os.environ.copy()
+    env['PORT'] = '8001'  # Use different port for testing
+    
+    # Start the server
+    process = subprocess.Popen([
+        sys.executable, 'app.py'
+    ], env=env, cwd='/workspace')
+    
+    # Wait a bit for server to start
+    time.sleep(3)
+    
+    return process
+
+def test_error_scenarios():
+    """Test various error scenarios to trigger stack traces."""
+    base_url = "http://localhost:8001"
+    
+    print("Testing error scenarios to verify stack trace logging...")
+    
+    # Test 1: Invalid URL format
+    print("\n1. Testing invalid URL format...")
+    try:
+        response = requests.post(
+            f"{base_url}/summarize",
+            json={"url": "not-a-valid-url"},
+            timeout=5
+        )
+        print(f"Response status: {response.status_code}")
+        print(f"Response: {response.json()}")
+    except Exception as e:
+        print(f"Request failed: {e}")
+    
+    # Test 2: Non-existent domain
+    print("\n2. Testing non-existent domain...")
+    try:
+        response = requests.post(
+            f"{base_url}/summarize", 
+            json={"url": "https://thisdoesnotexist12345.com"},
+            timeout=10
+        )
+        print(f"Response status: {response.status_code}")
+        print(f"Response: {response.json()}")
+    except Exception as e:
+        print(f"Request failed: {e}")
+    
+    # Test 3: Malformed request
+    print("\n3. Testing malformed request...")
+    try:
+        response = requests.post(
+            f"{base_url}/summarize",
+            json={"invalid_field": "test"},
+            timeout=5
+        )
+        print(f"Response status: {response.status_code}")
+        print(f"Response: {response.json()}")
+    except Exception as e:
+        print(f"Request failed: {e}")
+
+def main():
+    """Main function to run the test."""
+    print("Starting error handling test...")
+    
+    # Start the server
+    print("Starting server...")
+    server_process = start_server()
+    
+    try:
+        # Run tests
+        test_error_scenarios()
+        
+        print("\n" + "="*60)
+        print("Tests completed!")
+        print("Check the server console output above for detailed stack traces.")
+        print("The server should have logged full stack traces for any errors encountered.")
+        print("="*60)
+        
+    finally:
+        # Clean up - stop the server
+        print("\nStopping test server...")
+        server_process.terminate()
+        server_process.wait()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Configure the FastAPI server to log full stack traces of errors to the server console.

This change ensures that when an error occurs, the complete traceback is printed in the server's console output, providing crucial debugging information that was previously hidden behind generic 500 errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-bff66126-296d-4016-b414-a3010737dfeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bff66126-296d-4016-b414-a3010737dfeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

