### PR TITLE
Fix website content fetch error

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ class WebsiteSummarizationWorkflow(Workflow):
     @step
     async def fetch_website_content(self, ev: StartEvent) -> ContentFetched:
         """Fetch the content of the website."""
-        url = ev.data.get("url")
+        url = getattr(ev, 'url', None)
         if not url:
             raise ValueError("URL is required")
         


### PR DESCRIPTION
Fixes `AttributeError` when accessing URL from `StartEvent` by directly retrieving the `url` attribute.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a6f3f45-cc8d-4722-9b29-8b31830c7a17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a6f3f45-cc8d-4722-9b29-8b31830c7a17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

