### PR TITLE
Fix llama index context error

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,11 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, HttpUrl
 from contextlib import asynccontextmanager
 
+# Disable LlamaIndex instrumentation to prevent context token errors
+os.environ["LLAMA_INDEX_DISABLE_TELEMETRY"] = "true"
+
+# Also disable OpenTelemetry instrumentation if it's enabled
+os.environ["OTEL_SDK_DISABLED"] = "true"
 
 from llama_index.core.workflow import (
     Event,


### PR DESCRIPTION
Disable LlamaIndex and OpenTelemetry instrumentation to resolve context variable errors in async environments.

The `Failed to reset active_span_id` error occurred because LlamaIndex's instrumentation attempted to reset context variables across different async contexts, which is not supported. Disabling instrumentation prevents this conflict without impacting core application functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6cdd18b-7ae0-4d70-8d5d-5d789f84d06b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6cdd18b-7ae0-4d70-8d5d-5d789f84d06b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

