### PR TITLE
Enable options method for upload_pdfs endpoint

### DIFF
--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -127,6 +127,15 @@ class TestSummarizeEndpoint:
         assert "Allow" in response.headers
         assert "POST, OPTIONS" in response.headers["Allow"]
 
+    def test_upload_pdfs_options_request(self, client):
+        """Test OPTIONS request for upload_pdfs endpoint CORS handling."""
+        
+        response = client.options("/upload_pdfs")
+        
+        assert response.status_code == 200
+        assert "Allow" in response.headers
+        assert "POST, OPTIONS" in response.headers["Allow"]
+
 class TestAPIErrorHandling:
     """Test API-level error handling."""
     


### PR DESCRIPTION
Add a test for the `upload_pdfs` endpoint's OPTIONS method to verify its correct functionality and CORS handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-af0afb93-4db1-4b93-bee9-94a7a30b8a1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af0afb93-4db1-4b93-bee9-94a7a30b8a1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

