### PR TITLE
Fix pydantic schema generation error

### DIFF
--- a/app.py
+++ b/app.py
@@ -204,13 +204,23 @@ class PDFToGraphWorkflow(Workflow):
                 ],
             }
 
+            # Define entity properties for schema generation
+            entity_props = {
+                "GENE": {"description": "A gene or genetic element"},
+                "PATHWAY": {"description": "A biological pathway"},
+                "DISEASE": {"description": "A disease or medical condition"},
+                "TREATMENT": {"description": "A treatment or therapeutic intervention"},
+                "TREATMENT_OUTCOME": {"description": "An outcome or result of treatment"}
+            }
+
             # Initialize knowledge graph extractor
             kg_extractor = SchemaLLMPathExtractor(
                 llm=self.llm,
                 possible_entities=entities,
                 possible_relations=relations,
                 kg_validation_schema=validation_schema,
-                strict=True,
+                entity_props=entity_props,
+                strict=False,  # Set to False to avoid Pydantic schema generation issues
             )
 
             # Connect to Neo4j using environment variables


### PR DESCRIPTION
Fixes Pydantic schema generation error in `SchemaLLMPathExtractor`.

The `PydanticSchemaGenerationError` occurred because `SchemaLLMPathExtractor` failed to dynamically create Pydantic models from the list of entity strings in strict mode. This is resolved by providing `entity_props` for better schema inference and setting `strict=False` to allow the extractor to process entity types without strict Pydantic model generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-1dad7a23-b6cd-49b0-89e6-ad3fb47971b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1dad7a23-b6cd-49b0-89e6-ad3fb47971b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

