### PR TITLE
Add missing Literal import

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import traceback
 import logging
 import tempfile
 import shutil
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Literal
 from fastapi import FastAPI, HTTPException, Response, Request, UploadFile, File
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import JSONResponse


### PR DESCRIPTION
Add missing `Literal` import to `app.py` to resolve an `UnboundNameError` when using type annotations.

---
<a href="https://cursor.com/background-agent?bcId=bc-dba72c51-f7f3-4e00-b37d-33095a857d68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dba72c51-f7f3-4e00-b37d-33095a857d68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

